### PR TITLE
Add new configuration into *Mojo: Ability to filter only file by file an...

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,12 @@ The docker folder contains two images to build the plugin using java7 or
 java8
 
 
+Install Locally
+------
+
+By default jar is signed after packaging and before installation. To skip that (testing):
+```
+mvn -Dgpg.skip install
+```
+
 

--- a/src/main/java/com/xebialabs/maven/mustache/AbstractMustachifierMojo.java
+++ b/src/main/java/com/xebialabs/maven/mustache/AbstractMustachifierMojo.java
@@ -91,7 +91,7 @@ public abstract class AbstractMustachifierMojo extends AbstractMojo {
         TFile input = new TFile(aFile.getSourceFile());
         TFile output = new TFile(aFile.getTargetFileName());
         try {
-            String content = load(input, aFile.getModelEncoding());
+            String content = TFiles.toString(input, Charset.forName(aFile.getModelEncoding()));
             if (aFile.isFilterOnlyMustacheProperties()) {
                 content = filterMustacheOnly(content);
             }
@@ -101,6 +101,8 @@ public abstract class AbstractMustachifierMojo extends AbstractMojo {
             save(processed, output, aFile.getModelEncoding());
         } catch (MojoExecutionException e) {
             getLog().error("Failed to read input file: "+input, e);
+        } catch (IOException e) {
+            getLog().warn("Failed to read input file: "+input);
         }
     }
 

--- a/src/main/java/com/xebialabs/maven/mustache/SingleFile.java
+++ b/src/main/java/com/xebialabs/maven/mustache/SingleFile.java
@@ -1,0 +1,54 @@
+package com.xebialabs.maven.mustache;
+
+/**
+ * Created by clalleme on 31/03/2015.
+ */
+public class SingleFile {
+    public static final String UTF_8 = "UTF-8";
+    String sourceFile;
+    String targetFileName;
+    boolean filterOnlyMustacheProperties = false;
+    private String modelEncoding = UTF_8;
+
+
+    public SingleFile() {
+    }
+
+    public SingleFile(final String aSourceFile, final String aTargetFileName, final boolean aFilterOnlyMustacheProperties) {
+        sourceFile = aSourceFile;
+        targetFileName = aTargetFileName;
+        filterOnlyMustacheProperties = aFilterOnlyMustacheProperties;
+    }
+
+    public String getSourceFile() {
+        return sourceFile;
+    }
+
+    public void setSourceFile(final String aSourceFile) {
+        sourceFile = aSourceFile;
+    }
+
+    public String getTargetFileName() {
+        return targetFileName;
+    }
+
+    public void setTargetFileName(final String aTargetFileName) {
+        targetFileName = aTargetFileName;
+    }
+
+    public boolean isFilterOnlyMustacheProperties() {
+        return filterOnlyMustacheProperties;
+    }
+
+    public void setFilterOnlyMustacheProperties(final boolean aFilterOnlyMustacheProperties) {
+        filterOnlyMustacheProperties = aFilterOnlyMustacheProperties;
+    }
+
+    public String getModelEncoding() {
+        return modelEncoding;
+    }
+
+    public void setModelEncoding(final String aModelEncoding) {
+        modelEncoding = aModelEncoding;
+    }
+}

--- a/src/test/java/com/xebialabs/maven/mustache/AbstractMustachifierMojoTest.java
+++ b/src/test/java/com/xebialabs/maven/mustache/AbstractMustachifierMojoTest.java
@@ -1,0 +1,46 @@
+package com.xebialabs.maven.mustache;
+
+import junit.framework.Assert;
+import org.apache.maven.shared.model.fileset.FileSet;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
+public class AbstractMustachifierMojoTest {
+
+    final static String lineBreak = System.getProperty("line.separator");
+
+    @Test
+    public void testSaveSingleFile() throws Exception {
+        MustachifierToValueMojo mojo = new MustachifierToValueMojo();
+        mojo.setValueSeparator(":");
+        mojo.setDelimiters("{{ }}");
+        mojo.setFilesets(new ArrayList<FileSet>());
+        mojo.saveSingleFile(new SingleFile("./target/test-classes/mustache/withplaceholders/config.properties", "./target/test-classes/mustache/withplaceholders/config-test.properties\\", false));
+    }
+
+    @Test
+    public void testSaveSingleFileWithFiltering() throws Exception {
+        MustachifierToValueMojo mojo = new MustachifierToValueMojo();
+        mojo.setValueSeparator(":");
+        mojo.setDelimiters("{{ }}");
+        mojo.setFilesets(new ArrayList<FileSet>());
+        mojo.saveSingleFile(new SingleFile("./target/test-classes/mustache/withplaceholders/config.properties", "./target/test-classes/mustache/withplaceholders/config-filter.properties\\", true));
+    }
+
+
+    @Test
+    public void testFilterMustacheOnly() throws Exception {
+        MustachifierToValueMojo mojo = new MustachifierToValueMojo();
+        mojo.setValueSeparator(":");
+        mojo.setDelimiters("{{ }}");
+
+        String content = "Boo=2"+lineBreak+"test={{fdfsf}}"+lineBreak;
+        String result = mojo.filterMustacheOnly(content);
+        System.err.println("result: "+result);
+        Assert.assertTrue(result.contains("test"));
+        Assert.assertFalse(result.contains("Boo"));
+    }
+}

--- a/src/test/java/com/xebialabs/maven/mustache/SingleFileTest.java
+++ b/src/test/java/com/xebialabs/maven/mustache/SingleFileTest.java
@@ -1,0 +1,17 @@
+package com.xebialabs.maven.mustache;
+
+import junit.framework.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SingleFileTest {
+
+    @Test
+    public void should_contains_default_value() {
+        SingleFile file = new SingleFile();
+        Assert.assertEquals(SingleFile.UTF_8, file.getModelEncoding());
+        Assert.assertEquals(false, file.isFilterOnlyMustacheProperties());
+    }
+
+}


### PR DESCRIPTION
I need to filter file by file and change the location of result.
So I update the AbstractMojo to take into account new configuration property
I take the opportunity to make filesets property optionnal.
example of usage: 

```
<configuration>
    <files>
        <singlefile>
            <sourceFile>${project.build.directory}/config/${project.artifactId}.properties</sourceFile>
            <targetFileeName>${project.build.testOutputDirectory}/${project.artifactId}.properties</targetFileName>
           <filterOnlyMustacheProperties>false</filterOnlyMustacheProperties>
        </singlefile>
    </files>
</configuration>
```
